### PR TITLE
Expose charge calculator types to main for consitency

### DIFF
--- a/peleffy/main.py
+++ b/peleffy/main.py
@@ -14,12 +14,13 @@ import argparse as ap
 
 import peleffy
 from peleffy.utils import Logger, OutputPathHandler
+from peleffy.forcefield.selectors import ChargeCalculatorSelector
 
 
 DEFAULT_OFF_FORCEFIELD = 'openff_unconstrained-1.3.0.offxml'
 DEFAULT_RESOLUTION = int(30)
 DEFAULT_CHARGE_METHOD = 'am1bcc'
-AVAILABLE_CHARGE_METHODS = ['am1bcc', 'gasteiger', 'OPLS']
+AVAILABLE_CHARGE_METHODS = ChargeCalculatorSelector()._AVAILABLE_TYPES.keys()
 IMPACT_TEMPLATE_PATH = 'DataLocal/Templates/OFF/Parsley/HeteroAtoms/'
 ROTAMER_LIBRARY_PATH = 'DataLocal/LigandRotamerLibs/'
 SOLVENT_TEMPLATE_PATH = 'DataLocal/OBC/'


### PR DESCRIPTION
- [x] Tag issue being addressed
Addressing issue #113 
- [ ] Add [tests](https://github.com/martimunicoy/offpele/tree/master/offpele/tests)
- [ ] Update docstrings/[documentation](https://github.com/martimunicoy/offpele/tree/master/docs), if applicable
- [ ] Update [changelog](https://github.com/martimunicoy/offpele/blob/master/docs/releasehistory.rst)
- [ ] All tests successfully pass

The fix is really simple, just use the same list as the selector in the main. Therefore if in the future new methods are added it won't need updating.